### PR TITLE
Fixed Segmentation fault when try to get data after disconnect (#13)

### DIFF
--- a/mogilefs.c
+++ b/mogilefs.c
@@ -345,11 +345,10 @@ PHPAPI int mogilefs_sock_disconnect(MogilefsSock *mogilefs_sock TSRMLS_DC) { /* 
 /* }}} */
 
 PHPAPI int mogilefs_sock_close(MogilefsSock *mogilefs_sock TSRMLS_DC) { /* {{{ */
-	if (mogilefs_sock->stream == NULL) {
-		return 0;
-	}
 	mogilefs_sock->status = MOGILEFS_SOCK_STATUS_DISCONNECTED;
-	php_stream_close(mogilefs_sock->stream);
+	if (mogilefs_sock->stream != NULL) {
+		php_stream_close(mogilefs_sock->stream);
+	}
 	mogilefs_sock->stream = NULL;
 	return 1;
 }
@@ -430,6 +429,11 @@ PHPAPI int mogilefs_sock_get(zval *id, MogilefsSock **mogilefs_sock TSRMLS_DC) {
 /* }}} */
 
 PHPAPI int mogilefs_sock_eof(MogilefsSock *mogilefs_sock) { /* {{{ */
+	if (!mogilefs_sock || mogilefs_sock->stream == NULL) {
+		mogilefs_sock_close(mogilefs_sock);
+		zend_throw_exception(mogilefs_exception_ce, "Lost tracker connection", 0 TSRMLS_CC);
+		return 1;
+	}
 	if (php_stream_eof(mogilefs_sock->stream)) {
 		/* close socket but avoid writing on it again */
 		mogilefs_sock_close(mogilefs_sock);

--- a/package.xml
+++ b/package.xml
@@ -11,9 +11,9 @@ PHP MogileFS is a client library to communicate with MogileFS trackers. Those tr
 		<email>lstrojny@php.net</email>
 		<active>yes</active>
 	</lead>
-	<date>2013-01-11</date>
+	<date>2015-07-29</date>
 	<version>
-		<release>0.9.4-dev</release>
+		<release>0.9.4-rg</release>
 		<api>1.0</api>
 	</version>
 	<stability>

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@ PHP MogileFS is a client library to communicate with MogileFS trackers. Those tr
 	</lead>
 	<date>2015-07-29</date>
 	<version>
-		<release>0.9.4-rg</release>
+		<release>0.9.49</release>
 		<api>1.0</api>
 	</version>
 	<stability>

--- a/php_mogilefs.h
+++ b/php_mogilefs.h
@@ -32,7 +32,7 @@
 
 #ifndef PHP_MOGILEFS_H
 #define PHP_MOGILEFS_H
-#define PHP_MOGILEFS_VERSION "0.9.2-dev"
+#define PHP_MOGILEFS_VERSION "0.9.49"
 
 extern zend_module_entry mogilefs_module_entry;
 #define phpext_mogilefs_ptr &mogilefs_module_entry


### PR DESCRIPTION
Added check for mogilefs_sock->stream == NULL in mogilefs_sock_eof. This fixes issue #13.
Throws exception instead.

mogilefs_sock_close now sets the mogilefs_sock->status in all cases.